### PR TITLE
Add looping and fixed some songs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ This tells the library which pins you'd like to attach to the NES "voices". By d
 
 Inititalizes ultrasonic SigmaDelta generation on the pins from before, allowing for a free, hacky DAC!
 
-**cart.play_nes**(uint8_t* **vgm_data**);
+**cart.play_nes**(uint8_t* **vgm_data**, bool **looping**);
 
-This is where the magic happens. When cart.play_nes(music) is called, the ESP32 fires up the fake NES APU, resets it's registers, parses some data from the VGM header, and begins to play your music! Connect the four pins from above to the positive terminal of a speaker and enjoy! **This is a blocking function. Use the cart.frame_counter_cb() below to define code to be run during playback.**
+This is where the magic happens. When cart.play_nes(music) is called, the ESP32 fires up the fake NES APU, resets it's registers, parses some data from the VGM header, and begins to play your music! Connect the four pins from above to the positive terminal of a speaker and enjoy! Some tracks have loops built in - set *looping* to true and the track will restart after it ends, either at the beginning or a defined middle portion of the song. **This is a blocking function. Use the cart.frame_counter_cb() below to define code to be run during playback.**
 
 **cart.frame_counter_cb**(void **func**);
 

--- a/examples/NES_DEMO/NES_DEMO.ino
+++ b/examples/NES_DEMO/NES_DEMO.ino
@@ -93,7 +93,7 @@ void setup() {
   delay(1000);
   cart.play_nes(teleporting);
   delay(1000);
-  cart.play_nes(saving);
+  cart.play_nes(saving, true); // add true argument to make song loop
 }
 
 void loop() {

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -9,10 +9,10 @@
 static void (*fc_callback)(); 
 
 Cartridge::Cartridge(uint8_t p1_p, uint8_t p2_p, uint8_t n_p, uint8_t t_p) {
-	p1_pin = p1_p;
-	p2_pin = p2_p;
-	n_pin = n_p;
-	t_pin = t_p;
+  p1_pin = p1_p;
+  p2_pin = p2_p;
+  n_pin = n_p;
+  t_pin = t_p;
 }
 
 void Cartridge::frame_counter_cb(void (*action)()){
@@ -37,7 +37,7 @@ void Cartridge::init(){
   sigmaDeltaWrite(t_channel, 0);
 }
 
-void Cartridge::play_nes(uint8_t* music){
+void Cartridge::play_nes(uint8_t* music, bool looping){
   NES_PLAYING = true;
   read_vgm_header(music);
 
@@ -57,7 +57,7 @@ void Cartridge::play_nes(uint8_t* music){
 
     if (t_now >= next_audio) {
       next_audio += audio_period;
-      parse_vgm(music);
+      parse_vgm(music, looping);
 
       audio_counter++;
       if (audio_counter >= audio_divisor) {
@@ -71,7 +71,7 @@ void Cartridge::play_nes(uint8_t* music){
   }
 }
 
-void Cartridge::parse_vgm(uint8_t* music){
+void Cartridge::parse_vgm(uint8_t* music, bool looping){
   uint8_t extra = 0;
   if (vgm_wait == 0) {
     uint8_t command = music[vgm_index];
@@ -89,9 +89,26 @@ void Cartridge::parse_vgm(uint8_t* music){
     else if (command == 0x63) { // Wait 882 samples
       vgm_wait = 882;
     }
-    else if (command == 0x66) { // End of Sound Data
+    else if (command == 0x67 && music[vgm_index + 1] == 0x66) { // Start of data block
+      uint32_t block_size = (music[vgm_index + 3]      ) + 
+                  (music[vgm_index + 4] <<  8) + 
+                  (music[vgm_index + 5] << 16) + 
+                  (music[vgm_index + 6] << 24); 
+      vgm_index += block_size - 1;  // Basically ignore all data block contents
+    }
+    else if (command == 0x66 || vgm_index == VGM_EOF_OFFSET){
       Serial.println("END");
-      reset_nes();
+      if(looping) {
+        if(VGM_LOOP_OFFSET == 0) {  // Loop offset is not built into file
+          vgm_index = VGM_DATA_OFFSET - 1;  // Restart the song entirely
+        }
+        else {
+          vgm_index = VGM_LOOP_OFFSET - 1;  // Music loops, reset to looping byte
+        }
+      }
+      else {
+        reset_nes();  // Reset if loop opt-out
+      }
     }
     else if (command >= 0x70 && command < 0x80) { // Wait (0x7)n+1 samples
       uint8_t result = command;
@@ -121,6 +138,7 @@ void Cartridge::read_vgm_header(uint8_t* music){
   VGM_RATE = get_32_bit(music, 0x24);
   VGM_DATA_OFFSET = get_32_bit(music, 0x34) + 0x34;
   VGM_NES_APU_CLOCK = get_32_bit(music, 0x84);
+  VGM_LOOP_OFFSET = get_32_bit(music, 0x1C) - 0x1C;
 
   vgm_index = VGM_DATA_OFFSET;
 }
@@ -343,7 +361,7 @@ void Cartridge::clock_frame_counter(){
     if (apu_cycles == 3728) {
       clock_envelopes();
       clock_linear_counter();
-	  fc_callback();
+    fc_callback();
     }
     else if (apu_cycles == 7456) {
       clock_envelopes();
@@ -367,7 +385,7 @@ void Cartridge::clock_frame_counter(){
     if (apu_cycles == 3728) {
       clock_envelopes();
       clock_linear_counter();
-	  fc_callback();
+    fc_callback();
     }
     else if (apu_cycles == 7456) {
       clock_envelopes();

--- a/src/Cartridge.cpp
+++ b/src/Cartridge.cpp
@@ -138,7 +138,7 @@ void Cartridge::read_vgm_header(uint8_t* music){
   VGM_RATE = get_32_bit(music, 0x24);
   VGM_DATA_OFFSET = get_32_bit(music, 0x34) + 0x34;
   VGM_NES_APU_CLOCK = get_32_bit(music, 0x84);
-  VGM_LOOP_OFFSET = get_32_bit(music, 0x1C) - 0x1C;
+  VGM_LOOP_OFFSET = get_32_bit(music, 0x1C) + 0x1C;
 
   vgm_index = VGM_DATA_OFFSET;
 }

--- a/src/Cartridge.h
+++ b/src/Cartridge.h
@@ -14,11 +14,11 @@ class Cartridge
   public:
 	Cartridge(uint8_t p1_p = 12, uint8_t p2_p = 14, uint8_t n_p = 27, uint8_t t_p = 26);
 	void init();
-	void play_nes(uint8_t* music);
+	void play_nes(uint8_t* music, bool looping = false);
 	void frame_counter_cb(void (*action)());
 	
   private:
-	void parse_vgm(uint8_t* music);
+	void parse_vgm(uint8_t* music, bool looping);
 	void read_vgm_header(uint8_t* music);
 	uint32_t get_32_bit(uint8_t* music, uint32_t index);
 	void reset_nes();
@@ -177,6 +177,7 @@ class Cartridge
 	uint32_t VGM_RATE = 0;
 	uint32_t VGM_DATA_OFFSET = 0;
 	uint32_t VGM_NES_APU_CLOCK = 0;
+	uint32_t VGM_LOOP_OFFSET = 0;
 	
 };
 


### PR DESCRIPTION
Some tracks (e.g. all castlevania 2 tracks, some mario 3 tracks, plus more) don't play as they contain data blocks, which contain the byte 0x66 - which also ended the song. Added data block recognition, and for now will jump over the block and ignore all the internal bytes. In addition, VGM headers contain a loop offset, telling at what point the song will reset to when it ends. There's now code to recognize that, and if the user desires, loop the song using the second argument of `play_nes`. It has a default value of false, so omitting the argument will not repeat the song if omitted.